### PR TITLE
Update gulp-mjml to v2.0.0 and fix TypeError bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@
 var gulp = require('gulp'),
     mjml = require('gulp-mjml'),
     rename = require('gulp-rename');
-    Elixir = require('laravel-elixir');
 
 var config = Elixir.config;
 var Task = Elixir.Task;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "laravel-elixir": "^4.0.0",
     "gulp": "^3.8.8",
-    "gulp-mjml": "^1.0.1",
+    "gulp-mjml": "^2.0.0",
     "gulp-rename": "^1.0.0"
   },
   "author": "Peter Fox <peter.fox@peterfox.me>",


### PR DESCRIPTION
This was not working anymore at least with node v6.10.0 and npm v3.10.10
I fixed it by updating gulp-mjml to current version and removing the inclusion of the Elixir module from the index.js file.